### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ We list the inference scripts for different tasks mentioned in our paper as foll
 <img width="800" src="assets/boy_and_mom.gif"/>
 <br>
 
-We currently implemented multi-condition control on **I2VGen-XL**. The following checkpoint are trained on 7 control conditions, including depth, canny, normal, softedge, segmentation, lineart, and openpose. Here are the sample inference scripts that uses depth, canny, segmentation, and openpose as control conditions.
+We currently implemented multi-condition control on **I2VGen-XL**. The following checkpoints are trained on 7 control conditions, including depth, canny, normal, softedge, segmentation, lineart, and openpose. Here are the sample inference scripts that use depth, canny, segmentation, and openpose as control conditions.
 
 | Adapter Checkpoint    | Router Checkpoint | Inference (w/ extracted condition) | Inference (w/o extracted condition) |
 |-----------|------|---------|--------|

--- a/inference.py
+++ b/inference.py
@@ -261,7 +261,7 @@ def inference_main(inference_args):
     # create dir for condition images/frames 
     output_condition_images_dir = []
     for i, ctrl_type in enumerate(inference_args.control_types):
-        output_condition_images_dir.append(os.path.join(output_dir, f"conditon_{ctrl_type}_{inference_args.eval_input_type}"))
+        output_condition_images_dir.append(os.path.join(output_dir, f"condition_{ctrl_type}_{inference_args.eval_input_type}"))
         os.makedirs(output_condition_images_dir[-1], exist_ok=True)
 
     if inference_args.extract_control_conditions or inference_args.eval_input_type == 'frames':


### PR DESCRIPTION
Fix typos in `README.md`:
- `checkpoint` -> `checkpoints`
- `uses` -> `use`

Fix typos in `inference.py`:
- `conditon` -> `condition`